### PR TITLE
Schedule model-download job on GPU nodes for vLLM-NFS

### DIFF
--- a/reference-architectures/vllm-nfs/k8s/model-download-job.yaml
+++ b/reference-architectures/vllm-nfs/k8s/model-download-job.yaml
@@ -8,6 +8,12 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        doks.digitalocean.com/node-pool: ${gpu_node_pool_name}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/reference-architectures/vllm-nfs/terraform/2-vllm/main.tf
+++ b/reference-architectures/vllm-nfs/terraform/2-vllm/main.tf
@@ -71,8 +71,9 @@ resource "kubernetes_manifest" "hf_secret" {
 # 5. Job to download the model from HuggingFace to NFS
 resource "kubernetes_manifest" "model_download_job" {
   manifest = yamldecode(templatefile("${path.module}/../../k8s/model-download-job.yaml", {
-    model_id   = var.model_id
-    model_name = local.model_name
+    model_id           = var.model_id
+    model_name         = local.model_name
+    gpu_node_pool_name = local.gpu_node_pool_name
   }))
 
   wait {


### PR DESCRIPTION
## Summary
- Adds `nvidia.com/gpu` toleration and GPU node pool `nodeSelector` to the model-download job so it schedules on GPU nodes
- Passes `gpu_node_pool_name` from Terraform to the job template
- The `network-not-tuned` toleration is intentionally omitted — the gpu-network-tuner DaemonSet removes that taint before workloads schedule

## Test plan
- [ ] `cd reference-architectures/vllm-nfs && make lint` passes (verified locally)
- [ ] Deploy the reference architecture and confirm the model-download job schedules on a GPU node
- [ ] Confirm vLLM deployment still works end-to-end after the model download completes